### PR TITLE
Create and register orders app models to Admin 

### DIFF
--- a/orders/admin.py
+++ b/orders/admin.py
@@ -1,3 +1,15 @@
 from django.contrib import admin
+from .models import Order, OrderItem
 
 # Register your models here.
+class OrderItemInline(admin.TabularInline):
+    model = OrderItem
+    raw_id_fields = ['product']
+
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    list_display = ['id', 'first_name', 'last_name',
+                     'email', 'address', 'postal_code',
+                     'city', 'paid', 'created', 'updated']
+    list_filter = ['paid', 'created', 'updated']
+    inlines = [OrderItemInline]

--- a/orders/models.py
+++ b/orders/models.py
@@ -1,3 +1,39 @@
 from django.db import models
+from shop.models import Product 
 
 # Create your models here.
+class Order(models.Model):
+    first_name = models.CharField(max_length=200)
+    last_name = models.CharField(max_length=50)
+    email = models.EmailField()
+    address = models.CharField(max_length=250)
+    postal_code = models.CharField(max_length=20)
+    city = models.CharField(max_length=100)
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+    paid = models.BooleanField(default=False)
+
+    class Meta:
+        ordering=('-created',)
+
+    def __str__(self):
+        return f'Order {self.id}'
+    
+    def get_total_cost(self):
+        return sum(item.get_cost() for item in self.items.all())
+
+class OrderItem(models.Model):
+    order = models.ForeignKey(Order,
+                              related_name='items',
+                              on_delete=models.CASCADE)
+    product = models.ForeignKey(Product,
+                                related_name='items',
+                                on_delete=models.CASCADE)
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+    quantity = models.PositiveIntegerField(default=1)
+
+    def __str__(self):
+        return str(self.id)
+    
+    def get_cost(self):
+        return self.price * self.quantity


### PR DESCRIPTION
**Changes made:**

- Add the `Order` and `OrderItem` models to the `models.py` file of the orders application.
- Include the models in the administration site by modifying the `admin.py` file.