### PR TITLE
Integrate Braintree Payment Gateway for Checkout Process

### DIFF
--- a/myshop/settings.py
+++ b/myshop/settings.py
@@ -133,9 +133,14 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # BrainTree configuttion
 # Braintree settings
-BRAINTREE_MERCHANT_ID = '9t7qtc5csrqxr3dy' # Merchant ID
-BRAINTREE_PUBLIC_KEY = '9dp83p4pj9v2jr9c' # Public Key
-BRAINTREE_PRIVATE_KEY = '43c29aa4bb41b74da3015fb50696cfd1' # Private key
+
+import environ
+# Initialise environment variables
+env = environ.Env()
+environ.Env.read_env()
+BRAINTREE_MERCHANT_ID = env('BRAINTREE_MERCHANT_ID') # Merchant ID
+BRAINTREE_PUBLIC_KEY = env('BRAINTREE_PUBLIC_KEY') # Public Key
+BRAINTREE_PRIVATE_KEY = env('BRAINTREE_PRIVATE_KEY') # Private key
 
 import braintree
 BRAINTREE_CONF = braintree.Configuration(

--- a/myshop/settings.py
+++ b/myshop/settings.py
@@ -133,9 +133,9 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # BrainTree configuttion
 # Braintree settings
-BRAINTREE_MERCHANT_ID='9t7qtc5csrqxr3dy' #Mercent ID 
-BRAINTREE_PUBLIC_KEY='9dp83p4pj9v2jr9' #Public Key
-BRAINTREE_PRIVATE_KEY='43c29aa4bb41b74da3015fb50696cfd1'#Private Key
+BRAINTREE_MERCHANT_ID = '9t7qtc5csrqxr3dy' # Merchant ID
+BRAINTREE_PUBLIC_KEY = '9dp83p4pj9v2jr9c' # Public Key
+BRAINTREE_PRIVATE_KEY = '43c29aa4bb41b74da3015fb50696cfd1' # Private key
 
 import braintree
 BRAINTREE_CONF = braintree.Configuration(

--- a/myshop/settings.py
+++ b/myshop/settings.py
@@ -133,9 +133,9 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # BrainTree configuttion
 # Braintree settings
-BRAINTREE_MERCHANT_ID = '9t7qtc5csrqxr3dy' # Merchant ID
-BRAINTREE_PUBLIC_KEY = '9dp83p4pj9v2jr9c' # Public Key
-BRAINTREE_PRIVATE_KEY = '43c29aa4bb41b74da3015fb50696cfd1' # Private key
+BRAINTREE_MERCHANT_ID='9t7qtc5csrqxr3dy' #Mercent ID 
+BRAINTREE_PUBLIC_KEY='9dp83p4pj9v2jr9' #Public Key
+BRAINTREE_PRIVATE_KEY='43c29aa4bb41b74da3015fb50696cfd1'#Private Key
 
 import braintree
 BRAINTREE_CONF = braintree.Configuration(

--- a/myshop/settings.py
+++ b/myshop/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'shop.apps.ShopConfig',
     'cart.apps.CartConfig',
     'orders.apps.OrdersConfig',
+    'payment.apps.PaymentConfig',
 ]
 
 MIDDLEWARE = [
@@ -129,3 +130,16 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
 CART_SESSION_ID = 'cart'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+# BrainTree configuttion
+# Braintree settings
+BRAINTREE_MERCHANT_ID = '9t7qtc5csrqxr3dy' # Merchant ID
+BRAINTREE_PUBLIC_KEY = '9dp83p4pj9v2jr9c' # Public Key
+BRAINTREE_PRIVATE_KEY = '43c29aa4bb41b74da3015fb50696cfd1' # Private key
+
+import braintree
+BRAINTREE_CONF = braintree.Configuration(
+                                        braintree.Environment.Sandbox,
+                                        BRAINTREE_MERCHANT_ID,
+                                        BRAINTREE_PUBLIC_KEY,
+                                        BRAINTREE_PRIVATE_KEY)

--- a/myshop/urls.py
+++ b/myshop/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('cart/', include('cart.urls', namespace='cart')),
     path('orders/', include('orders.urls', namespace='orders')),
+    path('payment/', include('payment.urls', namespace='payment')),
     path('', include('shop.urls', namespace='shop')),
 ]
 from django.conf import settings

--- a/orders/models.py
+++ b/orders/models.py
@@ -12,7 +12,7 @@ class Order(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
     paid = models.BooleanField(default=False)
-
+    braintree_id = models.CharField(max_length=150, blank=True)
     class Meta:
         ordering=('-created',)
 

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,8 +1,10 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from .models import OrderItem
 from .forms import OrderCreateForm
 from cart.cart import Cart
 from .tasks import order_created
+from django.urls import reverse
+
 # Create your views here.
 def order_create(request):
     cart = Cart(request)
@@ -17,9 +19,8 @@ def order_create(request):
                                          quantity=item['quantity'])
             cart.clear()
             order_created.delay(order.id)
-            return render(request,
-                          'orders/order/created.html',
-                          {'order': order})
+            request.session['order_id'] = order.id
+            return redirect(reverse('payment:process'))
     else:
         form = OrderCreateForm()
     return render(request,

--- a/orders/views.py
+++ b/orders/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect
 from .models import OrderItem
 from .forms import OrderCreateForm
 from cart.cart import Cart
-from .tasks import order_created
+from .tasks import send_order_confirmation_email
 from django.urls import reverse
 
 # Create your views here.
@@ -18,7 +18,7 @@ def order_create(request):
                                          price=item['price'],
                                          quantity=item['quantity'])
             cart.clear()
-            order_created.delay(order.id)
+            send_order_confirmation_email.delay(order.id)
             request.session['order_id'] = order.id
             return redirect(reverse('payment:process'))
     else:

--- a/payment/admin.py
+++ b/payment/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/payment/apps.py
+++ b/payment/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class PaymentConfig(AppConfig):
+    name = 'payment'

--- a/payment/models.py
+++ b/payment/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/payment/templates/payment/canceled.html
+++ b/payment/templates/payment/canceled.html
@@ -1,0 +1,8 @@
+{% extends "shop/base.html" %}
+
+{% block title %}Payment canceled{% endblock %}
+
+{% block content %}
+  <h1>Your payment has not been processed</h1>
+  <p>There was a problem processing your payment.</p>
+{% endblock %}

--- a/payment/templates/payment/done.html
+++ b/payment/templates/payment/done.html
@@ -1,0 +1,8 @@
+{% extends "shop/base.html" %}
+
+{% block title %}Payment successful{% endblock %}
+
+{% block content %}
+  <h1>Your payment was successful</h1>
+  <p>Your payment has been processed successfully.</p>
+{% endblock %}

--- a/payment/templates/payment/process.html
+++ b/payment/templates/payment/process.html
@@ -1,0 +1,74 @@
+{% extends "shop/base.html" %}
+
+{% block title %}Pay by credit card{% endblock %}
+
+{% block content %}
+  <h1>Pay by credit card</h1>
+  <form id="payment" method="post">
+
+    <label for="card-number">Card Number</label>
+    <div id="card-number" class="field"></div>
+
+    <label for="cvv">CVV</label>
+    <div id="cvv" class="field"></div>
+
+    <label for="expiration-date">Expiration Date</label>
+    <div id="expiration-date" class="field"></div>
+
+    <input type="hidden" id="nonce" name="payment_method_nonce" value="">
+    {% csrf_token %}
+    <input type="submit" value="Pay">
+  </form>
+  <!-- includes the Braintree JS client SDK -->
+  <script src="https://js.braintreegateway.com/web/3.58.0/js/client.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/3.58.0/js/hosted-fields.min.js"></script>
+  <script>
+    var form = document.querySelector('#payment');
+    var submit = document.querySelector('input[type="submit"]');
+
+    braintree.client.create({
+      authorization: '{{ client_token }}'
+    }, function (clientErr, clientInstance) {
+      if (clientErr) {
+        console.error(clientErr);
+        return;
+      }
+
+      braintree.hostedFields.create({
+        client: clientInstance,
+        styles: {
+          'input': {'font-size': '13px'},
+          'input.invalid': {'color': 'red'},
+          'input.valid': {'color': 'green'}
+        },
+        fields: {
+          number: {selector: '#card-number'},
+          cvv: {selector: '#cvv'},
+          expirationDate: {selector: '#expiration-date'}
+        }
+      }, function (hostedFieldsErr, hostedFieldsInstance) {
+        if (hostedFieldsErr) {
+          console.error(hostedFieldsErr);
+          return;
+        }
+
+        submit.removeAttribute('disabled');
+
+        form.addEventListener('submit', function (event) {
+          event.preventDefault();
+
+          hostedFieldsInstance.tokenize(function (tokenizeErr, payload) {
+            if (tokenizeErr) {
+              console.error(tokenizeErr);
+              return;
+            }
+            // set nonce to send to the server
+            document.getElementById('nonce').value = payload.nonce;
+            // submit form
+            document.getElementById('payment').submit();
+          });
+        }, false);
+      });
+    });
+  </script>
+{% endblock %}

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/payment/urls.py
+++ b/payment/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import views
+app_name = 'payment'
+urlpatterns = [
+    path('process/', views.payment_process, name='process'),
+    path('done/', views.payment_done, name='done'),
+    path('canceled/', views.payment_canceled, name='canceled'),
+]

--- a/payment/views.py
+++ b/payment/views.py
@@ -1,0 +1,39 @@
+import braintree
+from django.shortcuts import render, redirect, get_object_or_404
+from django.conf import settings 
+from orders.models import Order
+
+# Create your views here.
+gateway = braintree.BraintreeGateway(settings.BRAINTREE_CONF)
+
+def payment_process(request):
+    order_id = request.session.get('order_id')
+    order = get_object_or_404(Order, id=order_id)
+    total_cost = order.get_total_cost()
+
+    if request.method == 'POST':
+        nonce = request.POST.get('payment_method_nonce', None)
+        result = gateway.transaction.sale({
+            'amount': f'{total_cost:.2f}',
+            'payment_method_nonce':nonce,
+            'options':{
+                'submit_for_settlement':True
+            }
+        })
+        if result.is_success:
+            order.paid = True
+            order.braintree_id = result.transaction.id 
+            order.save() 
+            return redirect('payment:done')
+        else:
+            return redirect('payment:canceled')
+    else:
+        client_token = gateway.client_token.generate()
+        return render(request, 'payment/process.html', 
+                      {'order':order, 'client_token':client_token})
+
+def payment_done(request):
+    return render(request, 'payment/done.html')
+
+def payment_canceled(request):
+    return render(request, 'payment/canceled.html')


### PR DESCRIPTION
**Changes made :**
- Created a new payment application.
- Added Braintree configuration to `settings.py`.
- Updated `orders/views/order_create` to redirect to the payment process after creating an order.
- Added a new field `braintree_id` to the Order model to store the transaction ID.
- Created new views for processing payment and handling successful/canceled `transactionspayment/views/payment_process`, `payment/views/payment_done`, `payment/views/payment_canceled`
- Created URLs for the payment app (`payment/urls.py`).
- Implemented Braintree Hosted Fields for secure credit card input in `payment/process.html`.
- Updated templates for successful and canceled transactions (`payment/done.html`, `payment/canceled.html`).
