### PR TITLE
Implement Order Export to CSV in Django Admin site

### DIFF
--- a/orders/admin.py
+++ b/orders/admin.py
@@ -6,6 +6,33 @@ class OrderItemInline(admin.TabularInline):
     model = OrderItem
     raw_id_fields = ['product']
 
+import csv
+import datetime 
+from django.http import HttpResponse
+
+def export_to_csv(modeladmin, request, queryset):
+    opts = modeladmin.model._meta
+    content_disposition = f'attachment; filename={opts.verbose_name}.csv'
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = content_disposition
+    writer = csv.writer(response)
+
+    fields = [field for field in opts.get_fields() if not field.many_to_many\
+    and not field.one_to_many]
+    # Write a first row with header information
+    writer.writerow([field.verbose_name for field in fields])
+    # Write data rows
+    for obj in queryset:
+        data_row = []
+        for field in fields:
+            value = getattr(obj, field.name)
+            if isinstance(value, datetime.datetime):
+                value = value.strftime('%d/%m/%Y')
+            data_row.append(value)
+        writer.writerow(data_row)
+    return response
+export_to_csv.short_description = 'Export to CSV'
+
 @admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
     list_display = ['id', 'first_name', 'last_name',
@@ -13,3 +40,4 @@ class OrderAdmin(admin.ModelAdmin):
                      'city', 'paid', 'created', 'updated']
     list_filter = ['paid', 'created', 'updated']
     inlines = [OrderItemInline]
+    actions = [export_to_csv]


### PR DESCRIPTION
**Changes made :**

- Added `export_to_csv` function to `orders/admin.py`.
- Modified `OrderAdmin` class to include `export_to_csv` in the actions list.