### PR TITLE
Implement Custom Order Detail View in Django Admin site

### DIFF
--- a/orders/admin.py
+++ b/orders/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from .models import Order, OrderItem
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 
 # Register your models here.
 class OrderItemInline(admin.TabularInline):
@@ -33,11 +35,15 @@ def export_to_csv(modeladmin, request, queryset):
     return response
 export_to_csv.short_description = 'Export to CSV'
 
+def order_detail(obj):
+    url = reverse('orders:admin_order_detail', args=[obj.id])
+    return mark_safe(f'<a href="{url}">View</a>')
+
 @admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
     list_display = ['id', 'first_name', 'last_name',
                      'email', 'address', 'postal_code',
-                     'city', 'paid', 'created', 'updated']
-    list_filter = ['paid', 'created', 'updated']
+                     'city', 'paid', 'created', 'updated',order_detail,]
+    list_filter = ['paid', 'created', 'updated',]
     inlines = [OrderItemInline]
     actions = [export_to_csv]

--- a/orders/templates/admin/orders/order/detail.html
+++ b/orders/templates/admin/orders/order/detail.html
@@ -1,0 +1,78 @@
+{% extends "admin/base_site.html" %}
+
+{% block title %}
+  Order {{ order.id }} {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url "admin:index" %}">Home</a> &rsaquo;
+    <a href="{% url "admin:orders_order_changelist" %}">Orders</a>
+    &rsaquo;
+    <a href="{% url "admin:orders_order_change" order.id %}">Order {{ order.id }}</a>
+    &rsaquo; Detail
+  </div>
+{% endblock %}
+
+{% block content %}
+<h1>Order {{ order.id }}</h1>
+<ul class="object-tools">
+  <li>
+    <a href="#" onclick="window.print();">Print order</a>
+  </li>
+</ul>
+<table>
+  <tr>
+    <th>Created</th>
+    <td>{{ order.created }}</td>
+  </tr>
+  <tr>
+    <th>Customer</th>
+    <td>{{ order.first_name }} {{ order.last_name }}</td>
+  </tr>
+  <tr>
+    <th>E-mail</th>
+    <td><a href="mailto:{{ order.email }}">{{ order.email }}</a></td>
+  </tr>
+  <tr>
+    <th>Address</th>
+    <td>{{ order.address }}, {{ order.postal_code }} {{ order.city }}</td>
+  </tr>
+  <tr>
+    <th>Total amount</th>
+    <td>${{ order.get_total_cost }}</td>
+  </tr>
+  <tr>
+    <th>Status</th>
+    <td>{% if order.paid %}Paid{% else %}Pending payment{% endif %}</td>
+  </tr>
+</table>
+
+<div class="module">
+  <h2>Items bought</h2>
+  <table style="width:100%">
+    <thead>
+      <tr>
+        <th>Product</th>
+        <th>Price</th>
+        <th>Quantity</th>
+        <th>Total</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in order.items.all %}
+        <tr class="row{% cycle "1" "2" %}">
+          <td>{{ item.product.name }}</td>
+          <td class="num">${{ item.price }}</td>
+          <td class="num">{{ item.quantity }}</td>
+          <td class="num">${{ item.get_cost }}</td>
+        </tr>
+      {% endfor %}
+      <tr class="total">
+        <td colspan="3">Total</td>
+        <td class="num">${{ order.get_total_cost }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -5,4 +5,5 @@ app_name = 'orders'
 
 urlpatterns = [
     path('create/' ,views.order_create, name='order_create'),
+    path('admin/order/<int:order_id>/', views.admin_order_detail, name='admin_order_detail'),
 ]

--- a/orders/views.py
+++ b/orders/views.py
@@ -4,6 +4,9 @@ from .forms import OrderCreateForm
 from cart.cart import Cart
 from .tasks import order_created
 from django.urls import reverse
+from django.contrib.admin.views.decorators import staff_member_required
+from django.shortcuts import get_object_or_404
+from .models import Order
 
 # Create your views here.
 def order_create(request):
@@ -26,3 +29,10 @@ def order_create(request):
     return render(request,
                 'orders/order/create.html',
                 {'cart': cart, 'form': form})
+
+@staff_member_required
+def admin_order_detail(request, order_id):
+    order = get_object_or_404(Order, id=order_id)
+    return render(request,
+                  'admin/orders/order/detail.html',
+                  {'order':order})


### PR DESCRIPTION
## **Changes made in orders application:**

**views.py:** 
- Added `admin_order_detail` view function:
- Retrieves the specified Order object.
- Renders the admin/orders/order/detail.html template with order data.
- Requires staff user authentication using `staff_member_required` decorator.

**urls.py:**
- Added URL pattern for `admin_order_detail` view.

**templates/admin/orders/order/detail.html:** 
- Created template for order details:
- Extends admin/base_site.html for consistent look and feel.
- Displays order information like ID, customer details, address, total cost, status, and item list.

**admin.py:**
- Added `order_detail` function to generate a "View" link for each order in the list view.
- Updated `OrderAdmin.list_display` to include the link.