### PR TITLE
Implement Order invoice PDF Generation with WeasyPrint in Admin

### DIFF
--- a/myshop/settings.py
+++ b/myshop/settings.py
@@ -148,3 +148,4 @@ BRAINTREE_CONF = braintree.Configuration(
                                         BRAINTREE_MERCHANT_ID,
                                         BRAINTREE_PUBLIC_KEY,
                                         BRAINTREE_PRIVATE_KEY)
+STATIC_ROOT = os.path.join(BASE_DIR, 'static/')

--- a/orders/admin.py
+++ b/orders/admin.py
@@ -39,16 +39,16 @@ def order_detail(obj):
     url = reverse('orders:admin_order_detail', args=[obj.id])
     return mark_safe(f'<a href="{url}">View</a>')
 
-def view_order_invoice(obj):
+def display_invoice_link(obj):
     url = reverse('orders:admin_order_pdf', args=[obj.id])
     return mark_safe(f'<a href="{url}">PDF</a>')
-view_order_invoice.short_description = 'Invoice'
+display_invoice_link.short_description = 'Invoice'
 
 @admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
     list_display = ['id', 'first_name', 'last_name',
                      'email', 'address', 'postal_code',
-                     'city', 'paid', 'created', 'updated',order_detail,view_order_invoice]
+                     'city', 'paid', 'created', 'updated',order_detail,display_invoice_link]
     list_filter = ['paid', 'created', 'updated',]
     inlines = [OrderItemInline]
     actions = [export_to_csv]

--- a/orders/admin.py
+++ b/orders/admin.py
@@ -39,16 +39,16 @@ def order_detail(obj):
     url = reverse('orders:admin_order_detail', args=[obj.id])
     return mark_safe(f'<a href="{url}">View</a>')
 
-def order_pdf(obj):
+def view_order_invoice(obj):
     url = reverse('orders:admin_order_pdf', args=[obj.id])
     return mark_safe(f'<a href="{url}">PDF</a>')
-order_pdf.short_description = 'Invoice'
+view_order_invoice.short_description = 'Invoice'
 
 @admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
     list_display = ['id', 'first_name', 'last_name',
                      'email', 'address', 'postal_code',
-                     'city', 'paid', 'created', 'updated',order_detail,order_pdf]
+                     'city', 'paid', 'created', 'updated',order_detail,view_order_invoice]
     list_filter = ['paid', 'created', 'updated',]
     inlines = [OrderItemInline]
     actions = [export_to_csv]

--- a/orders/admin.py
+++ b/orders/admin.py
@@ -39,11 +39,16 @@ def order_detail(obj):
     url = reverse('orders:admin_order_detail', args=[obj.id])
     return mark_safe(f'<a href="{url}">View</a>')
 
+def order_pdf(obj):
+    url = reverse('orders:admin_order_pdf', args=[obj.id])
+    return mark_safe(f'<a href="{url}">PDF</a>')
+order_pdf.short_description = 'Invoice'
+
 @admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
     list_display = ['id', 'first_name', 'last_name',
                      'email', 'address', 'postal_code',
-                     'city', 'paid', 'created', 'updated',order_detail,]
+                     'city', 'paid', 'created', 'updated',order_detail,order_pdf]
     list_filter = ['paid', 'created', 'updated',]
     inlines = [OrderItemInline]
     actions = [export_to_csv]

--- a/orders/templates/orders/order/pdf.html
+++ b/orders/templates/orders/order/pdf.html
@@ -1,0 +1,49 @@
+<html>
+<body>
+  <h1>My Shop</h1>
+  <p>
+    Invoice no. {{ order.id }}</br>
+    <span class="secondary">
+      {{ order.created|date:"M d, Y" }}
+    </span>
+  </p>
+
+  <h3>Bill to</h3>
+  <p>
+    {{ order.first_name }} {{ order.last_name }}<br>
+    {{ order.email }}<br>
+    {{ order.address }}<br>
+    {{ order.postal_code }}, {{ order.city }}
+  </p>
+
+  <h3>Items bought</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Product</th>
+        <th>Price</th>
+        <th>Quantity</th>
+        <th>Cost</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in order.items.all %}
+        <tr class="row{% cycle "1" "2" %}">
+          <td>{{ item.product.name }}</td>
+          <td class="num">${{ item.price }}</td>
+          <td class="num">{{ item.quantity }}</td>
+          <td class="num">${{ item.get_cost }}</td>
+        </tr>
+      {% endfor %}
+      <tr class="total">
+        <td colspan="3">Total</td>
+        <td class="num">${{ order.get_total_cost }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <span class="{% if order.paid %}paid{% else %}pending{% endif %}">
+    {% if order.paid %}Paid{% else %}Pending payment{% endif %}
+  </span>
+</body>
+</html>

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -6,5 +6,5 @@ app_name = 'orders'
 urlpatterns = [
     path('create/' ,views.order_create, name='order_create'),
     path('admin/order/<int:order_id>/', views.admin_order_detail, name='admin_order_detail'),
-    path('admin/order/<int:order_id>/pdf/', views.admin_order_pdf, name='admin_order_pdf'),
+    path('admin/order/<int:order_id>/pdf/', views.admin_order_pdf_generate, name='admin_order_pdf'),
 ]

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -6,5 +6,5 @@ app_name = 'orders'
 urlpatterns = [
     path('create/' ,views.order_create, name='order_create'),
     path('admin/order/<int:order_id>/', views.admin_order_detail, name='admin_order_detail'),
-    path('admin/order/<int:order_id>/pdf/', views.admin_order_pdf_generate, name='admin_order_pdf'),
+    path('admin/order/<int:order_id>/pdf/', views.generate_order_pdf, name='admin_order_pdf'),
 ]

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -6,4 +6,5 @@ app_name = 'orders'
 urlpatterns = [
     path('create/' ,views.order_create, name='order_create'),
     path('admin/order/<int:order_id>/', views.admin_order_detail, name='admin_order_detail'),
+    path('admin/order/<int:order_id>/pdf/', views.admin_order_pdf, name='admin_order_pdf'),
 ]

--- a/orders/views.py
+++ b/orders/views.py
@@ -41,7 +41,7 @@ def admin_order_detail(request, order_id):
                   {'order':order})
 
 @staff_member_required
-def admin_order_pdf_generate(request, order_id):
+def generate_order_pdf(request, order_id):
     order = get_object_or_404(Order, id=order_id)
     html = render_to_string('orders/order/pdf.html',{'order':order})
     response = HttpResponse(content_type='application/pdf')

--- a/orders/views.py
+++ b/orders/views.py
@@ -7,7 +7,10 @@ from django.urls import reverse
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import get_object_or_404
 from .models import Order
-
+from django.conf import settings 
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+import weasyprint
 # Create your views here.
 def order_create(request):
     cart = Cart(request)
@@ -36,3 +39,13 @@ def admin_order_detail(request, order_id):
     return render(request,
                   'admin/orders/order/detail.html',
                   {'order':order})
+
+@staff_member_required
+def admin_order_pdf(request, order_id):
+    order = get_object_or_404(Order, id=order_id)
+    html = render_to_string('orders/order/pdf.html',{'order':order})
+    response = HttpResponse(content_type='application/pdf')
+    response['Content-Disposition'] = f'filename=order_{order.id}.pdf'
+    weasyprint.HTML(string=html).write_pdf(response, 
+                                           stylesheets=[weasyprint.CSS(settings.STATIC_ROOT + 'css/pdf.css')])
+    return response

--- a/orders/views.py
+++ b/orders/views.py
@@ -41,7 +41,7 @@ def admin_order_detail(request, order_id):
                   {'order':order})
 
 @staff_member_required
-def admin_order_pdf(request, order_id):
+def admin_order_pdf_generate(request, order_id):
     order = get_object_or_404(Order, id=order_id)
     html = render_to_string('orders/order/pdf.html',{'order':order})
     response = HttpResponse(content_type='application/pdf')


### PR DESCRIPTION
**templates/orders/order/pdf.html:** Created new template for invoice layout.
- Displays order information like ID, date, customer details, address, items, total cost, and payment status.

**views.py:** Added `admin_order_pdf `view function:
- Retrieves the specified Order object.
- Renders the pdf.html template with order data.
- Uses WeasyPrint to generate a PDF file from the rendered HTML.
- Requires staff user authentication using `staff_member_required `decorator.

**settings.py:** Added STATIC_ROOT setting to specify static file path.
- Required for referencing pdf.css for PDF styling.

**admin.py:** Add link to `admin_order_pdf `view in the order list display.

**urls.py:** Add url to the view `admin_order_pdf`