### PR TITLE
Implement English and Spanish Support with django-parler

### DIFF
--- a/myshop/settings.py
+++ b/myshop/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'payment.apps.PaymentConfig',
     'coupons.apps.CouponsConfig',
     'rosetta',
+    'parler',
 ]
 
 MIDDLEWARE = [
@@ -118,6 +119,17 @@ LANGUAGES = (
  ('en', _('English')),
  ('es', _('Spanish')),
 )
+
+PARLER_LANGUAGES = {
+    None: (
+        {'code':'en'},
+        {'code':'es'},
+    ),
+    'default':{
+        'fallback': 'en',
+        'hide_untranslated': False
+    }
+}
 
 LOCALE_PATHS = (
  os.path.join(BASE_DIR, 'locale/'),

--- a/myshop/urls.py
+++ b/myshop/urls.py
@@ -16,13 +16,14 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from django.conf.urls.i18n import i18n_patterns
+from django.utils.translation import gettext_lazy as _
 
 urlpatterns = i18n_patterns(
-    path('admin/', admin.site.urls),
-    path('cart/', include('cart.urls', namespace='cart')),
-    path('orders/', include('orders.urls', namespace='orders')),
-    path('payment/', include('payment.urls', namespace='payment')),
-    path('coupons/', include('coupons.urls', namespace='coupons')),
+    path(_('admin/'), admin.site.urls),
+    path(_('cart/'), include('cart.urls', namespace='cart')),
+    path(_('orders/'), include('orders.urls', namespace='orders')),
+    path(_('payment/'), include('payment.urls', namespace='payment')),
+    path(_('coupons/'), include('coupons.urls', namespace='coupons')),
     path('rosetta/', include('rosetta.urls')),
     path('', include('shop.urls', namespace='shop')),
 )

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 from . import views
+from django.utils.translation import gettext_lazy as _
 
 app_name = 'orders'
 
 urlpatterns = [
-    path('create/' ,views.order_create, name='order_create'),
+    path(_('create/') ,views.order_create, name='order_create'),
     path('admin/order/<int:order_id>/', views.admin_order_detail, name='admin_order_detail'),
     path('admin/order/<int:order_id>/pdf/', views.admin_order_pdf, name='admin_order_pdf'),
 ]

--- a/shop/admin.py
+++ b/shop/admin.py
@@ -1,16 +1,21 @@
 from django.contrib import admin
 from .models import Category, Product
-
+from parler.admin import TranslatableAdmin
 
 @admin.register(Category)
-class CategoryAdmin(admin.ModelAdmin):
+class CategoryAdmin(TranslatableAdmin):
     list_display = ['name', 'slug']
-    prepopulated_fields = {'slug': ('name',)}
+
+    def get_prepopulated_fields(self, request, obj=None):
+         return {'slug': ('name',)}
 
 @admin.register(Product)
-class ProductAdmin(admin.ModelAdmin):
+class ProductAdmin(TranslatableAdmin):
     list_display = ['name', 'slug', 'price',
                     'available', 'created', 'updated']
     list_filter = ['available', 'created', 'updated']
     list_editable = ['price', 'available']
-    prepopulated_fields = {'slug': ('name',)}
+
+    def get_prepopulated_fields(self, request, obj=None):
+        return {'slug': ('name',)}
+

--- a/shop/models.py
+++ b/shop/models.py
@@ -1,14 +1,17 @@
 from django.db import models
 from django.urls import reverse
+from parler.models import TranslatableModel, TranslatedFields
 
-class Category(models.Model):
-    name = models.CharField(max_length=200,
-                            db_index=True)
-    slug = models.SlugField(max_length=200,
-                            unique=True)
+class Category(TranslatableModel):
+    translations = TranslatedFields(
+        name = models.CharField(max_length=200,
+                                db_index=True),
+        slug = models.SlugField(max_length=200,
+                                unique=True)
+    )
 
     class Meta:
-        ordering = ('name',)
+        #ordering = ('name',)
         verbose_name = 'category'
         verbose_name_plural = 'categories'
 
@@ -19,23 +22,23 @@ class Category(models.Model):
         return reverse('shop:product_list_by_category',
                        args=[self.slug])
 
-class Product(models.Model):
+class Product(TranslatableModel):
+    translations = TranslatedFields(name = models.CharField(max_length=200, db_index=True),
+                                     slug = models.SlugField(max_length=200, db_index=True),
+                                     description = models.TextField(blank=True))
     category = models.ForeignKey(Category,
                                  related_name='products',
                                  on_delete=models.CASCADE)
-    name = models.CharField(max_length=200, db_index=True)
-    slug = models.SlugField(max_length=200, db_index=True)
     image = models.ImageField(upload_to='products/%Y/%m/%d',
                               blank=True)
-    description = models.TextField(blank=True)
     price = models.DecimalField(max_digits=10, decimal_places=2)
     available = models.BooleanField(default=True)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
-    class Meta:
-        ordering = ('name',)
-        index_together = (('id', 'slug'),)
+    # class Meta:
+    #     ordering = ('name',)
+    #     index_together = (('id', 'slug'),)
 
     def __str__(self):
         return self.name

--- a/shop/views.py
+++ b/shop/views.py
@@ -7,7 +7,10 @@ def product_list(request, category_slug=None):
     categories = Category.objects.all()
     products = Product.objects.filter(available=True)
     if category_slug:
-        category = get_object_or_404(Category, slug=category_slug)
+        language = request.LANGUAGE_CODE
+        category = get_object_or_404(Category, 
+                                    translations__language_code=language,
+                                    translations__slug=category_slug)
         products = products.filter(category=category)
     return render(request,
                   'shop/product/list.html',
@@ -17,9 +20,11 @@ def product_list(request, category_slug=None):
 
 
 def product_detail(request, id, slug):
+    language = request.LANGUAGE_CODE
     product = get_object_or_404(Product,
                                 id=id,
-                                slug=slug,
+                                translations__language_code=language,
+                                translations__slug=slug,
                                 available=True)
     cart_product_form = CartAddProductForm()
     return render(request,


### PR DESCRIPTION
**Settings:**
- Added 'parler' to INSTALLED_APPS in `settings.py`.
- Defined PARLER_LANGUAGES in `settings.py` to specify available languages (English and Spanish) and default language settings.

**Models:**
- Updated Category and Product models to inherit from TranslatableModel from django-parler.
- Used TranslatedFields wrapper to mark translatable fields (name, slug, description).
- Addressed compatibility issues by commenting out unsupported Django features (ordering, index_together) for translated models.

**Admin:**
- Updated CategoryAdmin and ProductAdmin to inherit from TranslatableAdmin for managing translations.
- Implemented `get_prepopulated_fields` method to handle slug generation.

**Views:**
- Updated `product_list` and `product_detail` views to retrieve objects using translated fields based on the current language (request.LANGUAGE_CODE).

**urls.py**
- Added getlazy translations for `urlpatterns` for orders and myshop applications



