### PR TITLE
Implement US Zip Code validation in OrderCreateForm

### DIFF
--- a/myshop/settings.py
+++ b/myshop/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'coupons.apps.CouponsConfig',
     'rosetta',
     'parler',
+    'localflavor',
 ]
 
 MIDDLEWARE = [

--- a/orders/forms.py
+++ b/orders/forms.py
@@ -1,7 +1,9 @@
 from django import forms 
+from localflavor.us.forms import USZipCodeField
 from .models import Order
 
 class OrderCreateForm(forms.ModelForm):
+    postal_code = USZipCodeField()
     class Meta:
         model = Order
         fields = ['first_name', 'last_name', 'email',


### PR DESCRIPTION
**myshop/settings.py:**:
- Added localflavor to INSTALLED_APPS in settings.py.

**orders/forms.py:**
- Updated `OrderCreateForm` to include a `postal_code` field using USZipCodeField.